### PR TITLE
Implement Structured Output with Pydantic Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,23 @@ for chunk in llm.stream("Tell me what happened to the Dinosaurs?"):
 ```
 
 More features coming soon.
+
+## Structured Output (Pydantic)
+
+You can ask the model to return JSON that matches a Pydantic model and
+have the client validate and return typed objects using `with_structured_output()`:
+
+```python
+from pydantic import BaseModel
+from langchain_gradient import ChatGradient
+
+class Person(BaseModel):
+    name: str
+    age: int
+    email: str
+
+llm = ChatGradient(model="llama3.3-70b-instruct", api_key="your_key")
+structured = llm.with_structured_output(Person)
+person = structured.invoke(["Create a person named John, age 30, email john@example.com"])
+print(person)
+```

--- a/tests/unit_tests/test_structured_output.py
+++ b/tests/unit_tests/test_structured_output.py
@@ -1,0 +1,66 @@
+"""Unit tests for structured output parsing and validation."""
+
+from typing import List
+
+import pytest
+from pydantic import BaseModel
+
+from langchain_gradient.chat_models import ChatGradient
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+    email: str
+
+
+class DummyLLM(ChatGradient):
+    """A tiny fake LLM that returns a pre-canned response for testing."""
+
+    def __init__(self, content: str, **kwargs):
+        super().__init__(**kwargs)
+        self._content = content
+
+    def invoke(self, messages: List, **kwargs):
+        # mimic the object returned by ChatGradient.invoke used in code
+        class R:
+            def __init__(self, content):
+                self.content = content
+
+        return R(self._content)
+
+
+def test_single_structured_output_success():
+    json_str = '{"name": "John", "age": 30, "email": "john@example.com"}'
+    llm = DummyLLM(content=json_str)
+    structured = llm.with_structured_output(Person)
+    person = structured.invoke(messages=["prompt"])
+    assert isinstance(person, Person)
+    assert person.name == "John"
+
+
+def test_multiple_structured_output_success():
+    json_str = '[{"name": "Alice", "age": 25, "email": "a@example.com"}, {"name": "Bob", "age": 28, "email": "b@example.com"}]'
+    llm = DummyLLM(content=json_str)
+    structured = llm.with_structured_output(Person, multiple=True)
+    people = structured.invoke(messages=["prompt"])
+    assert isinstance(people, list)
+    assert all(isinstance(p, Person) for p in people)
+    assert people[0].name == "Alice"
+
+
+def test_invalid_json_raises():
+    llm = DummyLLM(content="not a json")
+    structured = llm.with_structured_output(Person)
+    with pytest.raises(ValueError):
+        structured.invoke(messages=["prompt"])
+
+
+def test_validation_error_raises():
+    # Missing age field
+    json_str = '{"name": "John", "email": "john@example.com"}'
+    llm = DummyLLM(content=json_str)
+    structured = llm.with_structured_output(Person)
+    with pytest.raises(ValueError) as e:
+        structured.invoke(messages=["prompt"])
+    assert "Validation error" in str(e.value)


### PR DESCRIPTION
**Summary**

Adds structured output support to the ChatGradient client by introducing with_structured_output(). This returns a lightweight wrapper that parses the model's text output as JSON and validates it using a provided Pydantic model, returning typed BaseModel instances (or lists of instances).

**What changed**

**chat_models.py**
       -Added with_structured_output() to ChatGradient.
       -Added StructuredChatGradient helper wrapper which:
          -Invokes the underlying LLM,
          -Parses string output as JSON,
          -Validates using Pydantic and returns model instances (or lists when multiple=True.
     -Handles parsing and validation errors with clear ValueError messages.

**test_structured_output.py (new)**
     -Unit tests for single-object success, multiple-object success, invalid JSON, and validation error cases. Tests are isolated and do not hit the network (use a small dummy LLM).


**README.md**
Example usage showing with_structured_output(Person)

fixes #10 