### PR TITLE
fix: adds a guard for empty choices

### DIFF
--- a/langchain_gradient/chat_models.py
+++ b/langchain_gradient/chat_models.py
@@ -382,6 +382,8 @@ class ChatGradient(BaseChatModel):
         try:
             stream = inference_client.chat.completions.create(**parameters)
             for completion in stream:
+                if not completion.choices:
+                    continue
                 delta = completion.choices[0].delta
                 
                 content = getattr(delta, "content", None) or ""

--- a/tests/unit_tests/test_chat_models.py
+++ b/tests/unit_tests/test_chat_models.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from types import SimpleNamespace
 from typing import Type
 
 from dotenv import load_dotenv
@@ -185,3 +186,42 @@ class TestToolCalling:
         # Should not raise, just skip the invalid tool call
         parsed = llm._parse_tool_calls(raw_tool_calls)
         assert len(parsed) == 0
+
+
+class TestStreaming:
+    """Unit tests for streaming behavior."""
+
+    def test_stream_skips_empty_choices_chunks(self, monkeypatch) -> None:
+        """Test that chunks with empty choices are ignored during streaming."""
+
+        class FakeGradient:
+            def __init__(self, **kwargs) -> None:
+                del kwargs
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                del kwargs
+                return iter(
+                    [
+                        SimpleNamespace(choices=[]),
+                        SimpleNamespace(
+                            choices=[
+                                SimpleNamespace(
+                                    delta=SimpleNamespace(
+                                        content="hello", tool_calls=None
+                                    )
+                                )
+                            ]
+                        ),
+                    ]
+                )
+
+        monkeypatch.setattr("langchain_gradient.chat_models.Gradient", FakeGradient)
+
+        llm = ChatGradient(model="llama3.3-70b-instruct", api_key="test-key")
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+
+        assert len(chunks) == 1
+        assert chunks[0].message.content == "hello"


### PR DESCRIPTION
Hello! Noticed this while working with the library. On chunks with empty choices (which happens fairly regularly), an out of range error message surfaces as chunk content which means the client has to manually scrub it.

Reproducible Example:

```bash
export GRADIENT_MODEL_ACCESS_KEY=<KEY>

poetry run python - <<'PY'

import os
from gradient import Gradient
from langchain_core.messages import HumanMessage
from langchain_gradient import ChatGradient
key = os.environ["GRADIENT_MODEL_ACCESS_KEY"]

llm = ChatGradient(model="openai-gpt-5.4", api_key=key)
print([c.content for c in llm.stream([HumanMessage("Say hi in one word.")])])
PY
```

Current output:

```
['Hi', '!', '[ERROR] list index out of range', '']
```

Fixed output:

```
['Hi', '!', '']
```