### PR TITLE
fix: update stale integration tests for current inference API

### DIFF
--- a/tests/integration_tests/test_chat_model_param_support.py
+++ b/tests/integration_tests/test_chat_model_param_support.py
@@ -14,7 +14,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 def test_openai_o3_mini_max_completion_tokens():
-    llm = ChatGradient(model="openai-o3-mini", api_key=API_KEY, max_tokens=256)
+    # o3-mini is a reasoning model: a small token budget can be consumed
+    # entirely by reasoning, leaving empty content. Use a budget large
+    # enough to also produce visible output.
+    llm = ChatGradient(model="openai-o3-mini", api_key=API_KEY, max_tokens=4096)
     prompt = [HumanMessage(content="Say hello to the world!")]
     result = llm.invoke(prompt)
     assert result.content

--- a/tests/integration_tests/test_chat_models.py
+++ b/tests/integration_tests/test_chat_models.py
@@ -143,9 +143,11 @@ def test_timeout_param() -> None:
     reason="No Gradient API key set",
 )
 def test_empty_prompt() -> None:
+    # The inference API accepts empty message content and returns a normal
+    # completion rather than raising an error.
     llm = ChatGradient(api_key=os.environ.get("DIGITALOCEAN_INFERENCE_KEY"))
-    with pytest.raises(Exception):
-        llm.invoke([HumanMessage(content="")])
+    result = llm.invoke([HumanMessage(content="")])
+    assert result.content is not None
 
 
 @pytest.mark.skipif(

--- a/tests/integration_tests/test_chat_models_all_models.py
+++ b/tests/integration_tests/test_chat_models_all_models.py
@@ -8,19 +8,13 @@ load_dotenv()
 
 MODELS_TO_TEST = [
     "openai-o3-mini",
-    "mistral-nemo-instruct-2407",
+    "mistral-3-14B",
     "openai-gpt-4o-mini",
     "openai-gpt-4o",
-    "llama3-8b-instruct",
+    "openai-gpt-oss-20b",
     "deepseek-r1-distill-llama-70b",
     "llama3.3-70b-instruct"
 ]
-
-# "llama3-70b-instruct",
-# "anthropic-claude-3.7-sonnet",
-# "anthropic-claude-3.5-sonnet",
-# "anthropic-claude-3.5-haiku",
-# "anthropic-claude-3-opus",
 
 @pytest.mark.skipif(
     not os.environ.get("DIGITALOCEAN_INFERENCE_KEY"),


### PR DESCRIPTION
## Summary
- Replace retired models in `test_chat_models_all_models.py`: `mistral-nemo-instruct-2407` → `mistral-3-14B` and `llama3-8b-instruct` → `openai-gpt-oss-20b` (both retired models now return 404 "model not found"; replacements verified against the live `/v1/models` catalog)
- Update `test_empty_prompt`: the inference API now accepts empty message content and returns a normal completion instead of raising an error
- Raise the o3-mini token budget in `test_openai_o3_mini_max_completion_tokens` from 256 to 4096: as a reasoning model, o3-mini can consume the entire small budget on reasoning and return empty content (`finish_reason: length`)
- Remove stale commented-out Claude 3.x model names

## Test plan
- [x] All updated tests pass against the live inference API
- [x] Full integration suite: only remaining failures are the known `stream_options` incompatibility (to be fixed separately)

Made with [Cursor](https://cursor.com)