### PR TITLE
chore: release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-23
+
+### Fixed
+- Streaming no longer crashes on chunks with empty `choices` (e.g. the usage-only final chunk emitted when `stream_options={"include_usage": True}`). Thanks @MrDiggles2! (#27)
+- `stream_options` is no longer sent on non-streaming requests. The inference API rejects it unless `stream=True`, so `invoke()` on models configured with `stream_options` failed with a 400 validation error. `usage_metadata` is still populated from the response. (#29)
+- `user_agent_version` now reports the actual installed package version instead of a hardcoded stale one.
+
+### Changed
+- Updated integration tests for the current inference API: replaced retired models (`mistral-nemo-instruct-2407`, `llama3-8b-instruct`) with currently served ones (`mistral-3-14B`, `openai-gpt-oss-20b`); empty prompts are now accepted by the API; raised the o3-mini test token budget so reasoning doesn't exhaust it. (#28)
+
 ## [0.2.0] - 2026-06-24
 
 ### Changed

--- a/langchain_gradient/chat_models.py
+++ b/langchain_gradient/chat_models.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from importlib.metadata import version
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Union
 
 from gradient import Gradient
@@ -171,7 +172,7 @@ class ChatGradient(BaseChatModel):
 
     @property
     def user_agent_version(self) -> str:
-        return "0.1.24"
+        return version("langchain-gradient")
     
     @property
     def _llm_type(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-gradient"
-version = "0.2.0"
+version = "0.2.1"
 description = "An integration package connecting Digitalocean and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1 (patch: bug fixes only)
- `user_agent_version` now reports the installed package version via `importlib.metadata` instead of a hardcoded `"0.1.24"`
- Changelog entry covering #27 (empty-choices streaming guard), #28 (integration test updates), #29 (stream_options on non-streaming requests)

## Test plan
- [x] Unit tests pass (21 passed)
- [x] `poetry build` artifacts install cleanly in a fresh venv; `user_agent_version` reports 0.2.1
- [ ] Publish to TestPyPI and verify install before prod PyPI release

Made with [Cursor](https://cursor.com)